### PR TITLE
add manyTill

### DIFF
--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -411,24 +411,23 @@ This parser can be used to scan comments:
 
     (string "<!--" *> manyTill anyChar (string "-->"))
 -}
-manyTill : Parser a -> Parser b -> Parser (List a)
+manyTill : Parser res -> Parser end -> Parser (List res)
 manyTill p end =
   let
-    loop acc =
-      Parser <| \cx ->
-        case app end cx of
-          (Fail err, cx) ->
-            case app p cx of
-              (Done c, cx') ->
-                app (loop (c::acc)) cx'
+    accumulate acc cx =
+      case app end cx of
+        (Fail err, cx) ->
+          case app p cx of
+            (Done res, cx') ->
+              accumulate (res :: acc) cx'
 
-              (Fail _, _) ->
-                (Fail err, cx)
+            _ ->
+              (Fail err, cx)
 
-          (Done succ, cx') ->
-            (Done (List.reverse acc), cx')
+        (Done _, cx') ->
+          (Done (List.reverse acc), cx')
   in
-    loop []
+    Parser <| accumulate []
 
 
 {-| Parser zero or more occurences of one parser separated by another.


### PR DESCRIPTION
Hi Bogdan,

I'm using your parser combinator lib for parsing XML responses (from a legacy web service). I love your lib so far, however I was missing one specific combinator, available in other parser combinator libs ([Haskell](https://hackage.haskell.org/package/parsec-3.1.9/docs/src/Text-Parsec-Combinator.html#manyTill), [F#](https://bitbucket.org/fparsec/main/src/6faaf8520b87f6b7292ce607c046eeb4715f05bf/FParsec/Primitives.fs?at=default&fileviewer=file-view-default#Primitives.fs-890)) called `manyTill`. It allows to process one parser till another parser matches.

This combinator is especially useful for parsing comments like for instance:

     (string "<!--" *> manyTill anyChar (string "-->"))

I'm not an expert in writing combinators (nor in elm) so I'm sure there exists a better implementation for this function.

Cheers
Tobias
