### PR TITLE
Short-circuit many function on unconsumed input

### DIFF
--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -406,7 +406,10 @@ many p =
     accumulate acc cx =
       case app p cx of
         (Ok res, cx') ->
-          accumulate (res :: acc) cx'
+          if cx == cx' then
+            (List.reverse acc, cx)
+          else
+            accumulate (res :: acc) cx'
 
         _ ->
           (List.reverse acc, cx)


### PR DESCRIPTION
Addresses issue:
  https://github.com/Bogdanp/elm-combine/issues/8

This fixes a bug where, for example, nested many calls fail to halt.